### PR TITLE
Bugfix: strings must be XML-encoded ("escaped")

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ First bring XML into Elm as a `Value`. Once imported as a Value, you can then ei
 
 Or you can turn it back to a string using `Xml.Encode.encode`. Or pull it apart using `Xml.Encode.Value`.
 
-In order to turn an `Xml.Value` into a record, you probably want `Xml.Query`, paired with `Result.map`.
+In order to turn an `Xml.Value` into a record, you probably want `Xml.Query`, paired with `Result.map`. Or use `xmlToJson` and your existing JSON decoder.
 
 ```elm
 
@@ -57,3 +57,13 @@ people =
 
 
 ```
+
+What's *not* supported yet:
+
+- [ ] Single-quoted attribute values (e.g. `<elem attr='val' />`)
+- [ ] Empty attributes are discarded (e.g. `<elem attr="">`)
+- [ ] Some special characters and consecutive whitespace in attribute values are not allowed (e.g. `<elem attr="=  ">`)
+- [ ] Element and attribute names are not checked for validity in `jsonToXml` which can lead to invalid XML.
+- [ ] …
+
+See skipped tests in [Tests.elm](tests/Tests.elm).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import Xml.Decode exposing (decode)
 import Xml.Query exposing (tags)
 
 decodedXml : Value
-decodedXml = 
+decodedXml =
 	"""
 <person>
 	<name>noah</name>
@@ -33,7 +33,7 @@ decodedXml =
 		|> Maybe.withDefault null
 
 
-type alias Person = 
+type alias Person =
 	{ name: String
 	, age: Int
 	}
@@ -60,10 +60,10 @@ people =
 
 What's *not* supported yet:
 
-- [ ] Single-quoted attribute values (e.g. `<elem attr='val' />`)
+- [ ] Single-quoted attribute values (e.g. `<elem attr='val'>`)
 - [ ] Empty attributes are discarded (e.g. `<elem attr="">`)
-- [ ] Some special characters and consecutive whitespace in attribute values are not allowed (e.g. `<elem attr="=  ">`)
-- [ ] Element and attribute names are not checked for validity in `jsonToXml` which can lead to invalid XML.
+- [ ] Some special characters and consecutive whitespace in attribute values are not allowed (e.g. `<elem attr="=">`)
+- [ ] Element and attribute names are not checked for validity in `object` and `jsonToXml` which can lead to invalid XML.
 - [ ] …
 
 See skipped tests in [Tests.elm](tests/Tests.elm).

--- a/elm.json
+++ b/elm.json
@@ -20,7 +20,7 @@
     "test-dependencies": {
         "elm/time": "1.0.0 <= v < 2.0.0",
         "elm-explorations/test": "1.1.0 <= v < 2.0.0",
-        "justinmimbs/time-extra": "1.0.1 <= v < 2.0.0",
+        "justinmimbs/time-extra": "1.1.1 <= v < 2.0.0",
         "rtfeldman/elm-iso8601-date-strings": "1.1.2 <= v < 2.0.0"
     }
 }

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -187,9 +187,9 @@ xmlDecoder =
         , JD.map IntNode JD.int
         , JD.map FloatNode JD.float
         , JD.map BoolNode JD.bool
-        , JD.map StrNode (JD.null "") -- this leads to an empty tag which is better than nothing
 
-        -- , JD.map Object (JD.null []) -- would it be better if the tag is omitted completely, i.e. Object []?
+        -- This is the most explicit way to store a null value:
+        , JD.map Object (JD.null [])
         , JD.list (JD.lazy (\_ -> xmlDecoder))
             |> JD.andThen
                 (\list ->

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -1,6 +1,7 @@
 module Xml exposing
     ( Value(..)
     , foldl, map, xmlToJson2, jsonToXml
+    , decodeXmlEntities, encodeXmlEntities
     )
 
 {-| The main data structure along with some trivial helpers.
@@ -63,6 +64,27 @@ foldl fn init value =
 
         anything ->
             fn anything init
+
+
+encodeXmlEntities : String -> String
+encodeXmlEntities s =
+    List.foldr (\( x, y ) z -> String.replace (String.fromChar x) ("&" ++ y ++ ";") z) s predefinedEntities
+
+
+decodeXmlEntities : String -> String
+decodeXmlEntities s =
+    List.foldr (\( x, y ) z -> String.replace ("&" ++ y ++ ";") (String.fromChar x) z) s predefinedEntities
+
+
+predefinedEntities : List ( Char, String )
+predefinedEntities =
+    -- https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references
+    [ ( '"', "quot" )
+    , ( '&', "amp" )
+    , ( '\'', "apos" )
+    , ( '<', "lt" )
+    , ( '>', "gt" )
+    ]
 
 
 {-| Convert an `Xml.Value` to a `Json.Value`

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -1,7 +1,7 @@
 module Xml exposing
     ( Value(..)
     , foldl, map, xmlToJson2, jsonToXml
-    , decodeXmlEntities, encodeXmlEntities
+    , decodeXmlEntities, encodeXmlEntities, xmlDecoder
     )
 
 {-| The main data structure along with some trivial helpers.
@@ -187,6 +187,9 @@ xmlDecoder =
         , JD.map IntNode JD.int
         , JD.map FloatNode JD.float
         , JD.map BoolNode JD.bool
+        , JD.map StrNode (JD.null "") -- this leads to an empty tag which is better than nothing
+
+        -- , JD.map Object (JD.null []) -- would it be better if the tag is omitted completely, i.e. Object []?
         , JD.list (JD.lazy (\_ -> xmlDecoder))
             |> JD.andThen
                 (\list ->

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -167,6 +167,11 @@ xmlDecoder =
                             case val of
                                 Object list ->
                                     list
+                                        -- reverse the list before it
+                                        -- is processed with foldl and
+                                        -- :: (which reverses the
+                                        -- order again)
+                                        |> List.reverse
                                         |> List.foldl
                                             (\v ( a_, p_ ) ->
                                                 case v of

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -66,24 +66,43 @@ foldl fn init value =
             fn anything init
 
 
+{-| Encode string with XML entities
+
+    encodeXmlEntities "<hello>"
+    --> "&lt;hello&gt;"
+
+-}
 encodeXmlEntities : String -> String
 encodeXmlEntities s =
     List.foldr (\( x, y ) z -> String.replace (String.fromChar x) ("&" ++ y ++ ";") z) s predefinedEntities
 
 
+{-| Decode string with XML entities
+
+    decodeXmlEntities "&lt;hello&gt;"
+    --> "<hello>"
+
+    Do not decode entities twice!
+
+    decodeXmlEntities "&amp;lt;hello&gt;"
+    --> "&lt;hello>"
+
+-}
 decodeXmlEntities : String -> String
 decodeXmlEntities s =
-    List.foldr (\( x, y ) z -> String.replace ("&" ++ y ++ ";") (String.fromChar x) z) s predefinedEntities
+    List.foldl (\( x, y ) z -> String.replace ("&" ++ y ++ ";") (String.fromChar x) z) s predefinedEntities
 
 
 predefinedEntities : List ( Char, String )
 predefinedEntities =
     -- https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references
     [ ( '"', "quot" )
-    , ( '&', "amp" )
     , ( '\'', "apos" )
     , ( '<', "lt" )
     , ( '>', "gt" )
+
+    -- & / &amp; must come last!
+    , ( '&', "amp" )
     ]
 
 

--- a/src/Xml/Decode.elm
+++ b/src/Xml/Decode.elm
@@ -16,7 +16,7 @@ module Xml.Decode exposing
 
 import Dict
 import Regex exposing (Regex)
-import Xml exposing (Value(..))
+import Xml exposing (Value(..), decodeXmlEntities)
 import Xml.Encode as Encode
 
 
@@ -219,10 +219,13 @@ decode text =
     decodeString "hello"
     --> Ok (StrNode "hello")
 
+    decodeString "hello &amp; good bye"
+    --> Ok (StrNode "hello & good bye")
+
 -}
 decodeString : String -> Result String Value
 decodeString str =
-    StrNode str
+    StrNode (decodeXmlEntities str)
         |> Ok
 
 

--- a/src/Xml/Encode.elm
+++ b/src/Xml/Encode.elm
@@ -144,10 +144,13 @@ encode indent value =
     string "hello" |> encode 0
     --> "hello"
 
+    string "<hello>" |> encode 0
+    --> "&lt;hello>"
+
 -}
 string : String -> Value
 string str =
-    StrNode str
+    StrNode (String.replace "<" "&lt;" str)
 
 
 {-| Encode an int

--- a/src/Xml/Encode.elm
+++ b/src/Xml/Encode.elm
@@ -16,7 +16,7 @@ module Xml.Encode exposing
 
 import Dict exposing (Dict)
 import String
-import Xml exposing (Value(..))
+import Xml exposing (Value(..), encodeXmlEntities)
 
 
 boolToString : Bool -> String
@@ -32,7 +32,7 @@ propToString : Value -> String
 propToString value =
     case value of
         StrNode str ->
-            str
+            encodeXmlEntities str
 
         IntNode n ->
             String.fromInt n
@@ -110,7 +110,7 @@ valueToString level indent value =
                 ++ ">"
 
         StrNode str ->
-            str
+            encodeXmlEntities str
 
         IntNode n ->
             String.fromInt n
@@ -149,8 +149,8 @@ encode indent value =
 
 -}
 string : String -> Value
-string str =
-    StrNode (String.replace "<" "&lt;" str)
+string =
+    StrNode
 
 
 {-| Encode an int

--- a/src/Xml/Encode.elm
+++ b/src/Xml/Encode.elm
@@ -145,7 +145,7 @@ encode indent value =
     --> "hello"
 
     string "<hello>" |> encode 0
-    --> "&lt;hello>"
+    --> "&lt;hello&gt;"
 
 -}
 string : String -> Value

--- a/tests/FuzzTests.elm
+++ b/tests/FuzzTests.elm
@@ -31,7 +31,13 @@ suite =
             \s ->
                 let
                     s1 =
-                        String.filter (\c -> not <| String.contains (String.fromChar c) "=\n\u{000D}\t ") s
+                        String.filter
+                            (\c ->
+                                not <|
+                                    -- I'm not sure why some characters are not allowed...
+                                    String.contains (String.fromChar c) "=\n\t "
+                            )
+                            s
 
                     val =
                         object

--- a/tests/FuzzTests.elm
+++ b/tests/FuzzTests.elm
@@ -1,0 +1,47 @@
+module FuzzTests exposing (..)
+
+import Dict
+import Expect exposing (Expectation)
+import Fuzz as Fuzz exposing (Fuzzer, int, list)
+import Test exposing (..)
+import Xml.Decode exposing (..)
+import Xml.Encode exposing (..)
+
+
+suite : Test
+suite =
+    describe "encoding and decoding works"
+        [ fuzz Fuzz.string "works for random string values" <|
+            \s ->
+                let
+                    val =
+                        string s
+                in
+                decodeString (encode 0 val) |> Expect.equal (Ok val)
+        , fuzz Fuzz.string "works for random string values within tags" <|
+            \s ->
+                let
+                    val =
+                        -- string must be non-empty because otherwise
+                        -- decoding doesn't know that it is a string
+                        object [ ( "tagname", Dict.empty, string ("x" ++ s) ) ]
+                in
+                decode (encode 0 val) |> Expect.equal (Ok val)
+        , fuzz Fuzz.string "works for random strings as attribute values" <|
+            \s ->
+                let
+                    s1 =
+                        String.filter (\c -> not <| String.contains (String.fromChar c) "=\n\u{000D}\t ") s
+
+                    val =
+                        object
+                            [ ( "tagname"
+                                -- string must be non-empty because otherwise
+                                -- decoding doesn't know that it is a string
+                              , Dict.fromList [ ( "attrname", string ("x" ++ s1) ) ]
+                              , null
+                              )
+                            ]
+                in
+                decode (encode 0 val) |> Expect.equal (Ok val)
+        ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -331,4 +331,14 @@ all =
                         object [ ( "tagname", Dict.empty, list [] ) ]
                 in
                 Expect.equal (decode "<tagname/>") (Ok val)
+        , describe "XML character entities &xxx;"
+            [ test "decode entities, each only once" <|
+                \_ -> decodeXmlEntities "&amp;quot;" |> Expect.equal "&quot;"
+            , test "decode entity" <|
+                \_ -> decodeXmlEntities "&quot;" |> Expect.equal "\""
+            , test "encode entity" <|
+                \_ -> encodeXmlEntities "&" |> Expect.equal "&amp;"
+            , test "encode entities, each only once" <|
+                \_ -> encodeXmlEntities "&quot;" |> Expect.equal "&amp;quot;"
+            ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -355,11 +355,10 @@ all =
                         (JD.decodeString xmlDecoder """{"a":true}""")
                         (Ok <| Tag "a" Dict.empty (BoolNode True))
             , test "decodes null" <|
-                -- TODO how should it behave?
                 \_ ->
                     Expect.equal
                         (JD.decodeString xmlDecoder """{"a":null}""")
-                        (Ok <| Tag "a" Dict.empty (StrNode ""))
+                        (Ok <| Tag "a" Dict.empty (Object []))
             , test "decodes plain list" <|
                 \_ ->
                     Expect.equal
@@ -374,7 +373,7 @@ all =
                 \_ ->
                     Expect.equal
                         (JD.decodeString xmlDecoder """[null, 1]""")
-                        (Ok <| Object [ StrNode "", IntNode 1 ])
+                        (Ok <| Object [ Object [], IntNode 1 ])
             , test "decode plain object" <|
                 \_ ->
                     Expect.equal
@@ -392,7 +391,7 @@ all =
                         (Ok <|
                             Object
                                 [ Tag "a" Dict.empty (IntNode 1)
-                                , Tag "b" Dict.empty (StrNode "")
+                                , Tag "b" Dict.empty (Object [])
                                 ]
                         )
             ]
@@ -418,16 +417,38 @@ all =
                                 , ( "tag2", Dict.empty, null )
                                 ]
                         )
-            , test "encode object JSON object with one null field" <|
+            , test "encode JSON object with one null field" <|
                 \_ ->
                     Expect.equal
-                        "<tag1></tag1>\n<tag2></tag2>"
+                        "<tag1>x</tag1>\n<tag2></tag2>"
                         (encode 0 <|
                             jsonToXml <|
                                 JE.object
                                     [ ( "tag1", JE.string "x" )
                                     , ( "tag2", JE.null )
                                     ]
+                        )
+            , test "xmlDecoder decodes JSON object with exactly one null field" <|
+                \_ ->
+                    Expect.equal
+                        (Ok <| Tag "tag" Dict.empty (Object []))
+                        (JD.decodeValue xmlDecoder <|
+                            JE.object [ ( "tag", JE.null ) ]
+                        )
+            , test "xmlDecoder decodes JSON object with one null field" <|
+                \_ ->
+                    Expect.equal
+                        (Ok <|
+                            Object
+                                [ Tag "tag1" Dict.empty (StrNode "x")
+                                , Tag "tag2" Dict.empty (Object [])
+                                ]
+                        )
+                        (JD.decodeValue xmlDecoder <|
+                            JE.object
+                                [ ( "tag1", JE.string "x" )
+                                , ( "tag2", JE.null )
+                                ]
                         )
             ]
         , describe "XML character entities &xxx;"


### PR DESCRIPTION
Hi @billstclair,

Thanks for this package. I noticed two issues while using it today.

Can you accept and publish PRs? That would be better than another version of the same package at package.elm-lang.org

One thing is that it does not escape `<` when encoding strings. Same problem at decoding.

This PR is just a quick fix / PoC but I could work on it.

The other issue is when encoding a list of objects. In that case, the object's keys are "inlined" but they should be surrounded by some "wrapper tag".