### PR TITLE
[WIP] Validate XML tag names and attribute names before creating Value

### DIFF
--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -3,6 +3,7 @@ module Xml exposing
     , foldl, map
     , xmlToJson2, jsonToXml, xmlDecoder
     , decodeXmlEntities, encodeXmlEntities
+    , isValidXmlName
     )
 
 {-| The main data structure along with some trivial helpers.
@@ -33,6 +34,7 @@ Please try to use UTF-8 / Unicode instead.
 import Dict exposing (Dict)
 import Json.Decode as JD
 import Json.Encode as Json
+import Regex
 
 
 {-| Representation of the XML tree
@@ -123,6 +125,17 @@ predefinedEntities =
     -- & / &amp; must come last!
     , ( '&', "amp" )
     ]
+
+
+isValidXmlName : String -> Bool
+isValidXmlName =
+    let
+        nameRegex =
+            -- O'Reilly: XML in a Nutshell: https://docstore.mik.ua/orelly/xml/xmlnut/ch02_04.htm
+            Maybe.withDefault Regex.never
+                (Regex.fromString "^[_a-zA-Z0-9\\p{Letter}][-_.:a-zA-Z0-9\\p{Letter}]*$")
+    in
+    Regex.contains nameRegex
 
 
 {-| Convert an `Xml.Value` to a `Json.Value`

--- a/src/Xml/Encode.elm
+++ b/src/Xml/Encode.elm
@@ -1,6 +1,7 @@
 module Xml.Encode exposing
     ( encode, encodeWith, EncodeSettings, defaultEncodeSettings
     , string, int, float, bool, object, null, list
+    , objectSafe
     )
 
 {-| Use this module for turning your Elm data into an `Xml`
@@ -12,6 +13,9 @@ string.
 @docs string, int, float, bool, object, null, list
 
 -}
+
+-- TODO: Attribute names AND tag names must be validated.
+-- Tags are also created in jsonToXml!
 
 import Dict exposing (Dict)
 import String
@@ -246,20 +250,15 @@ object values =
         |> Object
 
 
-
--- TODO: Attribute names AND tag names must be validated.
--- Tags are also created in jsonToXml!
-
-
 {-| Encode an "object" (a tag) only allowing valid tag names
 
     import Dict
 
-    objectSafe [ (" no valid tag!", Dict.empty, string "") ]
-    --> Err "Invalid tag names: no valid tag!"
-
     objectSafe [ ("tagname", Dict.empty, string "") ]
-    --> Ok "<tagname/>"
+    --> Ok (object [ ("tagname", Dict.empty, string "") ])
+
+    objectSafe [ ("invalid!!", Dict.empty, string "") ]
+    --> Err "Invalid tag names: invalid!!"
 
 -}
 objectSafe : List ( String, Dict String Value, Value ) -> Result String Value

--- a/src/Xml/Encode.elm
+++ b/src/Xml/Encode.elm
@@ -15,7 +15,7 @@ string.
 
 import Dict exposing (Dict)
 import String
-import Xml exposing (Value(..), encodeXmlEntities)
+import Xml exposing (Value(..), encodeXmlEntities, isValidXmlName)
 
 
 {-| Settings used by `encodeWith`.
@@ -244,6 +244,45 @@ object : List ( String, Dict String Value, Value ) -> Value
 object values =
     List.map (\( name, props, value ) -> Tag name props value) values
         |> Object
+
+
+
+-- TODO: Attribute names AND tag names must be validated.
+-- Tags are also created in jsonToXml!
+
+
+{-| Encode an "object" (a tag) only allowing valid tag names
+
+    import Dict
+
+    objectSafe [ (" no valid tag!", Dict.empty, string "") ]
+    --> Err "Invalid tag names: no valid tag!"
+
+    objectSafe [ ("tagname", Dict.empty, string "") ]
+    --> Ok "<tagname/>"
+
+-}
+objectSafe : List ( String, Dict String Value, Value ) -> Result String Value
+objectSafe values =
+    let
+        invalidTagNames =
+            List.filterMap
+                (\( name, _, _ ) ->
+                    if isValidXmlName name then
+                        Nothing
+
+                    else
+                        Just name
+                )
+                values
+    in
+    if List.isEmpty invalidTagNames then
+        List.map (\( name, props, value ) -> Tag name props value) values
+            |> Object
+            |> Ok
+
+    else
+        Err ("Invalid tag names: " ++ String.concat (List.intersperse ", " invalidTagNames))
 
 
 {-| Encode a list of nodes, e.g


### PR DESCRIPTION
If tag names and attribute names are not validated this can lead to invalid XML output.

Validation must be done in any function that create `Tag`s, that is at least:

- `object`
- `jsonToXml`

