### PR TITLE
Encode decode settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ First bring XML into Elm as a `Value`. Once imported as a Value, you can then ei
 
 Or you can turn it back to a string using `Xml.Encode.encode`. Or pull it apart using `Xml.Encode.Value`.
 
-In order to turn an `Xml.Value` into a record, you probably want `Xml.Query`, paired with `Result.map`.
+In order to turn an `Xml.Value` into a record, you probably want `Xml.Query`, paired with `Result.map`. Or use `xmlToJson` and your existing JSON decoder.
 
 ```elm
 
@@ -57,3 +57,13 @@ people =
 
 
 ```
+
+What's *not* supported yet:
+
+- [ ] Single-quoted attribute values (e.g. `<elem attr='val' />`)
+- [ ] Empty attributes are discarded (e.g. `<elem attr="">`)
+- [ ] Some special characters and consecutive whitespace in attribute values are not allowed (e.g. `<elem attr="=  ">`)
+- [ ] Element and attribute names are not checked for validity in `jsonToXml` which can lead to invalid XML.
+- [ ] …
+
+See skipped tests in [Tests.elm](tests/Tests.elm).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import Xml.Decode exposing (decode)
 import Xml.Query exposing (tags)
 
 decodedXml : Value
-decodedXml = 
+decodedXml =
 	"""
 <person>
 	<name>noah</name>
@@ -33,7 +33,7 @@ decodedXml =
 		|> Maybe.withDefault null
 
 
-type alias Person = 
+type alias Person =
 	{ name: String
 	, age: Int
 	}
@@ -60,10 +60,10 @@ people =
 
 What's *not* supported yet:
 
-- [ ] Single-quoted attribute values (e.g. `<elem attr='val' />`)
+- [ ] Single-quoted attribute values (e.g. `<elem attr='val'>`)
 - [ ] Empty attributes are discarded (e.g. `<elem attr="">`)
-- [ ] Some special characters and consecutive whitespace in attribute values are not allowed (e.g. `<elem attr="=  ">`)
-- [ ] Element and attribute names are not checked for validity in `jsonToXml` which can lead to invalid XML.
+- [ ] Some special characters and consecutive whitespace in attribute values are not allowed (e.g. `<elem attr="=">`)
+- [ ] Element and attribute names are not checked for validity in `object` and `jsonToXml` which can lead to invalid XML.
 - [ ] …
 
 See skipped tests in [Tests.elm](tests/Tests.elm).

--- a/elm.json
+++ b/elm.json
@@ -20,7 +20,7 @@
     "test-dependencies": {
         "elm/time": "1.0.0 <= v < 2.0.0",
         "elm-explorations/test": "1.1.0 <= v < 2.0.0",
-        "justinmimbs/time-extra": "1.0.1 <= v < 2.0.0",
+        "justinmimbs/time-extra": "1.1.1 <= v < 2.0.0",
         "rtfeldman/elm-iso8601-date-strings": "1.1.2 <= v < 2.0.0"
     }
 }

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -138,6 +138,9 @@ Renamed from xmlToJson to force a bump to version 2.0.
     xmlToJson2 (DocType "" Dict.empty)
     --> Json.null
 
+    xmlToJson2 NullNode
+    --> Json.null
+
 -}
 xmlToJson2 : Value -> Json.Value
 xmlToJson2 xml =

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -193,7 +193,7 @@ xmlDecoder =
         , JD.map BoolNode JD.bool
 
         -- This is the most explicit way to store a null value:
-        , JD.map Object (JD.null [])
+        , JD.map (\_ -> NullNode) (JD.null 0)
         , JD.list (JD.lazy (\_ -> xmlDecoder))
             |> JD.andThen
                 (\list ->

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -25,6 +25,7 @@ type Value
     | IntNode Int
     | FloatNode Float
     | BoolNode Bool
+    | NullNode
     | Object (List Value)
     | DocType String (Dict String Value)
 
@@ -170,6 +171,9 @@ xmlToJson2 xml =
 
         BoolNode bool ->
             Json.bool bool
+
+        NullNode ->
+            Json.null
 
         Object values ->
             Json.list xmlToJson2 values

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -1,14 +1,32 @@
 module Xml exposing
     ( Value(..)
-    , foldl, map, xmlToJson2, jsonToXml
-    , decodeXmlEntities, encodeXmlEntities, xmlDecoder
+    , foldl, map
+    , xmlToJson2, jsonToXml, xmlDecoder
+    , decodeXmlEntities, encodeXmlEntities
     )
 
 {-| The main data structure along with some trivial helpers.
 
 @docs Value
 
-@docs foldl, map, xmlToJson2, jsonToXml
+@docs foldl, map
+
+
+# XML/JSON conversion
+
+This library can convert to and from `Json.Value`.
+
+@docs xmlToJson2, jsonToXml, xmlDecoder
+
+
+# XML character entities
+
+This library can encode and decode the five predefined XML character entities.
+Numeric character references and other named HTML entities (e.g. `&#x20ac;`
+or `&euro;`) are currently not supported.
+Please try to use UTF-8 / Unicode instead.
+
+@docs decodeXmlEntities, encodeXmlEntities
 
 -}
 

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -187,9 +187,9 @@ xmlDecoder =
         , JD.map IntNode JD.int
         , JD.map FloatNode JD.float
         , JD.map BoolNode JD.bool
-        , JD.map StrNode (JD.null "") -- this leads to an empty tag which is better than nothing
 
-        -- , JD.map Object (JD.null []) -- would it be better if the tag is omitted completely, i.e. Object []?
+        -- This is the most explicit way to store a null value:
+        , JD.map Object (JD.null [])
         , JD.list (JD.lazy (\_ -> xmlDecoder))
             |> JD.andThen
                 (\list ->

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -1,6 +1,7 @@
 module Xml exposing
     ( Value(..)
     , foldl, map, xmlToJson2, jsonToXml
+    , decodeXmlEntities, encodeXmlEntities
     )
 
 {-| The main data structure along with some trivial helpers.
@@ -63,6 +64,27 @@ foldl fn init value =
 
         anything ->
             fn anything init
+
+
+encodeXmlEntities : String -> String
+encodeXmlEntities s =
+    List.foldr (\( x, y ) z -> String.replace (String.fromChar x) ("&" ++ y ++ ";") z) s predefinedEntities
+
+
+decodeXmlEntities : String -> String
+decodeXmlEntities s =
+    List.foldr (\( x, y ) z -> String.replace ("&" ++ y ++ ";") (String.fromChar x) z) s predefinedEntities
+
+
+predefinedEntities : List ( Char, String )
+predefinedEntities =
+    -- https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references
+    [ ( '"', "quot" )
+    , ( '&', "amp" )
+    , ( '\'', "apos" )
+    , ( '<', "lt" )
+    , ( '>', "gt" )
+    ]
 
 
 {-| Convert an `Xml.Value` to a `Json.Value`

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -1,7 +1,7 @@
 module Xml exposing
     ( Value(..)
     , foldl, map, xmlToJson2, jsonToXml
-    , decodeXmlEntities, encodeXmlEntities
+    , decodeXmlEntities, encodeXmlEntities, xmlDecoder
     )
 
 {-| The main data structure along with some trivial helpers.
@@ -187,6 +187,9 @@ xmlDecoder =
         , JD.map IntNode JD.int
         , JD.map FloatNode JD.float
         , JD.map BoolNode JD.bool
+        , JD.map StrNode (JD.null "") -- this leads to an empty tag which is better than nothing
+
+        -- , JD.map Object (JD.null []) -- would it be better if the tag is omitted completely, i.e. Object []?
         , JD.list (JD.lazy (\_ -> xmlDecoder))
             |> JD.andThen
                 (\list ->

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -167,6 +167,11 @@ xmlDecoder =
                             case val of
                                 Object list ->
                                     list
+                                        -- reverse the list before it
+                                        -- is processed with foldl and
+                                        -- :: (which reverses the
+                                        -- order again)
+                                        |> List.reverse
                                         |> List.foldl
                                             (\v ( a_, p_ ) ->
                                                 case v of

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -66,24 +66,43 @@ foldl fn init value =
             fn anything init
 
 
+{-| Encode string with XML entities
+
+    encodeXmlEntities "<hello>"
+    --> "&lt;hello&gt;"
+
+-}
 encodeXmlEntities : String -> String
 encodeXmlEntities s =
     List.foldr (\( x, y ) z -> String.replace (String.fromChar x) ("&" ++ y ++ ";") z) s predefinedEntities
 
 
+{-| Decode string with XML entities
+
+    decodeXmlEntities "&lt;hello&gt;"
+    --> "<hello>"
+
+    Do not decode entities twice!
+
+    decodeXmlEntities "&amp;lt;hello&gt;"
+    --> "&lt;hello>"
+
+-}
 decodeXmlEntities : String -> String
 decodeXmlEntities s =
-    List.foldr (\( x, y ) z -> String.replace ("&" ++ y ++ ";") (String.fromChar x) z) s predefinedEntities
+    List.foldl (\( x, y ) z -> String.replace ("&" ++ y ++ ";") (String.fromChar x) z) s predefinedEntities
 
 
 predefinedEntities : List ( Char, String )
 predefinedEntities =
     -- https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references
     [ ( '"', "quot" )
-    , ( '&', "amp" )
     , ( '\'', "apos" )
     , ( '<', "lt" )
     , ( '>', "gt" )
+
+    -- & / &amp; must come last!
+    , ( '&', "amp" )
     ]
 
 

--- a/src/Xml/Decode.elm
+++ b/src/Xml/Decode.elm
@@ -20,6 +20,17 @@ import Xml exposing (Value(..), decodeXmlEntities)
 import Xml.Encode as Encode
 
 
+type alias DecodeSettings =
+    { nullValues : List String
+    , trueValues : List String
+    , falseValues : List String
+    }
+
+
+defaultDecodeSettings =
+    { nullValues = [ "" ], trueValues = [ "true" ], falseValues = [ "false" ] }
+
+
 {-| Try and decode the props from a string
 -}
 decodeProps : String -> Result String Value
@@ -202,7 +213,22 @@ actualDecode text =
 
 -}
 decode : String -> Result String Value
-decode text =
+decode =
+    decodeWith defaultDecodeSettings
+
+
+{-| Try to decode a string and turn it into an XML value
+
+    import Xml exposing(Value(..))
+    import Xml.Encode exposing (null)
+    import Dict
+
+    decode "<name></name>"
+    --> Ok (Object [Tag "name" Dict.empty null])
+
+-}
+decodeWith : DecodeSettings -> String -> Result String Value
+decodeWith setts text =
     case String.trim text of
         "" ->
             Ok (Object [])

--- a/src/Xml/Decode.elm
+++ b/src/Xml/Decode.elm
@@ -1,17 +1,19 @@
 module Xml.Decode exposing
-    ( decode
+    ( decode, decodeWith, DecodeSettings, defaultDecodeSettings
     , decodeInt, decodeFloat, decodeString, decodeBool
     , decodeChildren
-    , decodeBoolWith, decodeFloatWith, decodeIntWith, decodeNull, decodeWith, defaultDecodeSettings
+    , decodeBoolWith, decodeFloatWith, decodeIntWith, decodeNull
     )
 
 {-|
 
-@docs decode
+@docs decode, decodeWith, DecodeSettings, defaultDecodeSettings
 
 @docs decodeInt, decodeFloat, decodeString, decodeBool
 
 @docs decodeChildren
+
+@docs decodeBoolWith, decodeFloatWith, decodeIntWith, decodeNull
 
 -}
 
@@ -21,6 +23,15 @@ import Xml exposing (Value(..), decodeXmlEntities)
 import Xml.Encode as Encode
 
 
+{-| Settings used by `decodeWith`.
+
+The `*Values` fields define lists of possible values for the
+respecitve node types, e.g. `["true", "True"]` for `True`.
+
+`parseNumbers` specifies if numbers are parsed to
+`IntNode`/`FloatNode` or just `StrNode`.
+
+-}
 type alias DecodeSettings =
     { nullValues : List String
     , trueValues : List String
@@ -29,6 +40,9 @@ type alias DecodeSettings =
     }
 
 
+{-| Good default settings for `DecodeSettings`.
+-}
+defaultDecodeSettings : DecodeSettings
 defaultDecodeSettings =
     { nullValues = [ "" ]
     , trueValues = [ "true" ]
@@ -263,7 +277,7 @@ errNumberParsingDisabled =
     Err "number parsing is disabled"
 
 
-{-| Decode a int
+{-| Decode an int
 
     import Xml exposing (Value(..))
 
@@ -279,6 +293,8 @@ decodeInt =
     decodeIntWith defaultDecodeSettings
 
 
+{-| Decode an int with settings
+-}
 decodeIntWith : DecodeSettings -> String -> Result String Value
 decodeIntWith { parseNumbers } str =
     if not parseNumbers then
@@ -313,6 +329,8 @@ decodeFloat =
     decodeFloatWith defaultDecodeSettings
 
 
+{-| Decode a float with settings
+-}
 decodeFloatWith : DecodeSettings -> String -> Result String Value
 decodeFloatWith { parseNumbers } str =
     if not parseNumbers then
@@ -335,6 +353,8 @@ decodeBool =
     decodeBoolWith defaultDecodeSettings
 
 
+{-| Decode a bool with settings
+-}
 decodeBoolWith : DecodeSettings -> String -> Result String Value
 decodeBoolWith setts str =
     if List.member str setts.trueValues then

--- a/src/Xml/Decode.elm
+++ b/src/Xml/Decode.elm
@@ -16,7 +16,7 @@ module Xml.Decode exposing
 
 import Dict
 import Regex exposing (Regex)
-import Xml exposing (Value(..))
+import Xml exposing (Value(..), decodeXmlEntities)
 import Xml.Encode as Encode
 
 
@@ -219,10 +219,13 @@ decode text =
     decodeString "hello"
     --> Ok (StrNode "hello")
 
+    decodeString "hello &amp; good bye"
+    --> Ok (StrNode "hello & good bye")
+
 -}
 decodeString : String -> Result String Value
 decodeString str =
-    StrNode str
+    StrNode (decodeXmlEntities str)
         |> Ok
 
 

--- a/src/Xml/Decode.elm
+++ b/src/Xml/Decode.elm
@@ -2,6 +2,7 @@ module Xml.Decode exposing
     ( decode
     , decodeInt, decodeFloat, decodeString, decodeBool
     , decodeChildren
+    , decodeNull, decodeWith, defaultDecodeSettings
     )
 
 {-|

--- a/src/Xml/Encode.elm
+++ b/src/Xml/Encode.elm
@@ -1,15 +1,13 @@
 module Xml.Encode exposing
-    ( encode
+    ( encode, encodeWith, EncodeSettings, defaultEncodeSettings
     , string, int, float, bool, object, null, list
-    , defaultEncodeSettings, encodeWith
     )
 
-{-|
+{-| Use this module for turning your Elm data into an `Xml`
+representation that can be either queried or decoded, or turned into a
+string.
 
-    Use this module for turning your Elm data into an `Xml` representation that can be either
-    queried or decoded, or turned into a string.
-
-@docs encode
+@docs encode, encodeWith, EncodeSettings, defaultEncodeSettings
 
 @docs string, int, float, bool, object, null, list
 
@@ -20,15 +18,25 @@ import String
 import Xml exposing (Value(..), encodeXmlEntities)
 
 
+{-| Settings used by `encodeWith`.
+
+  - `nullValue`: if not `omitNullTag`, encode a `NullNode` like this.
+  - `omitNullTag`: if `True`, omit a tag if it has no attributes and
+    its only content is a `NullNode`.
+
+-}
 type alias EncodeSettings =
-    { nullValue : String -- if not omitNullTag, encode NullNode like this
+    { nullValue : String
     , trueValue : String -- encode True like this
     , falseValue : String -- encode False like this
-    , omitNullTag : Bool -- omit a tag if it has no attributes and its only content is a NullNode
+    , omitNullTag : Bool
     , attributeSingleQuoteInsteadOfDouble : Bool
     }
 
 
+{-| Good default settings for `EncodeSettings`.
+-}
+defaultEncodeSettings : EncodeSettings
 defaultEncodeSettings =
     { nullValue = ""
     , trueValue = "true"

--- a/src/Xml/Encode.elm
+++ b/src/Xml/Encode.elm
@@ -144,10 +144,13 @@ encode indent value =
     string "hello" |> encode 0
     --> "hello"
 
+    string "<hello>" |> encode 0
+    --> "&lt;hello>"
+
 -}
 string : String -> Value
 string str =
-    StrNode str
+    StrNode (String.replace "<" "&lt;" str)
 
 
 {-| Encode an int

--- a/src/Xml/Encode.elm
+++ b/src/Xml/Encode.elm
@@ -16,7 +16,7 @@ module Xml.Encode exposing
 
 import Dict exposing (Dict)
 import String
-import Xml exposing (Value(..))
+import Xml exposing (Value(..), encodeXmlEntities)
 
 
 boolToString : Bool -> String
@@ -32,7 +32,7 @@ propToString : Value -> String
 propToString value =
     case value of
         StrNode str ->
-            str
+            encodeXmlEntities str
 
         IntNode n ->
             String.fromInt n
@@ -110,7 +110,7 @@ valueToString level indent value =
                 ++ ">"
 
         StrNode str ->
-            str
+            encodeXmlEntities str
 
         IntNode n ->
             String.fromInt n
@@ -149,8 +149,8 @@ encode indent value =
 
 -}
 string : String -> Value
-string str =
-    StrNode (String.replace "<" "&lt;" str)
+string =
+    StrNode
 
 
 {-| Encode an int

--- a/src/Xml/Encode.elm
+++ b/src/Xml/Encode.elm
@@ -145,7 +145,7 @@ encode indent value =
     --> "hello"
 
     string "<hello>" |> encode 0
-    --> "&lt;hello>"
+    --> "&lt;hello&gt;"
 
 -}
 string : String -> Value

--- a/src/Xml/Query.elm
+++ b/src/Xml/Query.elm
@@ -204,6 +204,9 @@ tags tagName node =
         FloatNode _ ->
             []
 
+        NullNode ->
+            []
+
         DocType _ _ ->
             []
 
@@ -240,6 +243,9 @@ contains contents node =
                 False
 
             FloatNode _ ->
+                False
+
+            NullNode ->
                 False
 
             DocType _ _ ->

--- a/tests/FuzzTests.elm
+++ b/tests/FuzzTests.elm
@@ -31,7 +31,13 @@ suite =
             \s ->
                 let
                     s1 =
-                        String.filter (\c -> not <| String.contains (String.fromChar c) "=\n\u{000D}\t ") s
+                        String.filter
+                            (\c ->
+                                not <|
+                                    -- I'm not sure why some characters are not allowed...
+                                    String.contains (String.fromChar c) "=\n\t "
+                            )
+                            s
 
                     val =
                         object

--- a/tests/FuzzTests.elm
+++ b/tests/FuzzTests.elm
@@ -1,0 +1,47 @@
+module FuzzTests exposing (..)
+
+import Dict
+import Expect exposing (Expectation)
+import Fuzz as Fuzz exposing (Fuzzer, int, list)
+import Test exposing (..)
+import Xml.Decode exposing (..)
+import Xml.Encode exposing (..)
+
+
+suite : Test
+suite =
+    describe "encoding and decoding works"
+        [ fuzz Fuzz.string "works for random string values" <|
+            \s ->
+                let
+                    val =
+                        string s
+                in
+                decodeString (encode 0 val) |> Expect.equal (Ok val)
+        , fuzz Fuzz.string "works for random string values within tags" <|
+            \s ->
+                let
+                    val =
+                        -- string must be non-empty because otherwise
+                        -- decoding doesn't know that it is a string
+                        object [ ( "tagname", Dict.empty, string ("x" ++ s) ) ]
+                in
+                decode (encode 0 val) |> Expect.equal (Ok val)
+        , fuzz Fuzz.string "works for random strings as attribute values" <|
+            \s ->
+                let
+                    s1 =
+                        String.filter (\c -> not <| String.contains (String.fromChar c) "=\n\u{000D}\t ") s
+
+                    val =
+                        object
+                            [ ( "tagname"
+                                -- string must be non-empty because otherwise
+                                -- decoding doesn't know that it is a string
+                              , Dict.fromList [ ( "attrname", string ("x" ++ s1) ) ]
+                              , null
+                              )
+                            ]
+                in
+                decode (encode 0 val) |> Expect.equal (Ok val)
+        ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -436,14 +436,13 @@ all =
                 \_ ->
                     Expect.equal
                         (JD.decodeString xmlDecoder """{"a":null}""")
-                        (Ok <| Tag "a" Dict.empty (Object []))
+                        (Ok <| Tag "a" Dict.empty NullNode)
             , test "decodes plain list" <|
                 \_ ->
                     Expect.equal
                         (JD.decodeString xmlDecoder """["a", 1]""")
                         (Ok <| Object [ StrNode "a", IntNode 1 ])
             , test "decodes empty list" <|
-                -- same as "null"! not good!
                 \_ ->
                     Expect.equal
                         (JD.decodeString xmlDecoder "[]")
@@ -457,7 +456,7 @@ all =
                 \_ ->
                     Expect.equal
                         (JD.decodeString xmlDecoder """[null, 1]""")
-                        (Ok <| Object [ Object [], IntNode 1 ])
+                        (Ok <| Object [ NullNode, IntNode 1 ])
             , test "decode plain object" <|
                 \_ ->
                     Expect.equal
@@ -475,12 +474,11 @@ all =
                         (Ok <|
                             Object
                                 [ Tag "a" Dict.empty (IntNode 1)
-                                , Tag "b" Dict.empty (Object [])
+                                , Tag "b" Dict.empty NullNode
                                 ]
                         )
             ]
-        , describe
-            "Find bug: json object with many fields is encoded as '' if one field is null"
+        , describe "Find bug: json object with many fields is encoded as '' if one field is null"
             [ test "object with one empty tag" <|
                 \_ ->
                     Expect.equal
@@ -504,7 +502,7 @@ all =
             , test "encode JSON object with one null field" <|
                 \_ ->
                     Expect.equal
-                        "<tag1>x</tag1>\n<tag2></tag2>"
+                        "<tag1>x</tag1>\n"
                         (encode 0 <|
                             jsonToXml <|
                                 JE.object
@@ -515,7 +513,7 @@ all =
             , test "xmlDecoder decodes JSON object with exactly one null field" <|
                 \_ ->
                     Expect.equal
-                        (Ok <| Tag "tag" Dict.empty (Object []))
+                        (Ok <| Tag "tag" Dict.empty NullNode)
                         (JD.decodeValue xmlDecoder <|
                             JE.object [ ( "tag", JE.null ) ]
                         )
@@ -525,7 +523,7 @@ all =
                         (Ok <|
                             Object
                                 [ Tag "tag1" Dict.empty (StrNode "x")
-                                , Tag "tag2" Dict.empty (Object [])
+                                , Tag "tag2" Dict.empty NullNode
                                 ]
                         )
                         (JD.decodeValue xmlDecoder <|

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -331,4 +331,14 @@ all =
                         object [ ( "tagname", Dict.empty, list [] ) ]
                 in
                 Expect.equal (decode "<tagname/>") (Ok val)
+        , describe "XML character entities &xxx;"
+            [ test "decode entities, each only once" <|
+                \_ -> decodeXmlEntities "&amp;quot;" |> Expect.equal "&quot;"
+            , test "decode entity" <|
+                \_ -> decodeXmlEntities "&quot;" |> Expect.equal "\""
+            , test "encode entity" <|
+                \_ -> encodeXmlEntities "&" |> Expect.equal "&amp;"
+            , test "encode entities, each only once" <|
+                \_ -> encodeXmlEntities "&quot;" |> Expect.equal "&amp;quot;"
+            ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -329,7 +329,7 @@ all =
             [ test "Decode bool True" <|
                 \_ ->
                     Expect.equal
-                        (decodeBool
+                        (decodeBoolWith
                             { defaultDecodeSettings | trueValues = [ "1" ] }
                             "1"
                         )
@@ -337,7 +337,7 @@ all =
             , test "Decode bool False" <|
                 \_ ->
                     Expect.equal
-                        (decodeBool
+                        (decodeBoolWith
                             { defaultDecodeSettings | falseValues = [ "0", "False" ] }
                             "False"
                         )
@@ -350,6 +350,30 @@ all =
                             "nil"
                         )
                         (Ok NullNode)
+            , test "Do not decode integers if not parseNumbers" <|
+                \_ ->
+                    Expect.equal
+                        (decodeIntWith
+                            { defaultDecodeSettings | parseNumbers = False }
+                            "1"
+                        )
+                        (Err "number parsing is disabled")
+            , test "Do not decode floats if not parseNumbers" <|
+                \_ ->
+                    Expect.equal
+                        (decodeFloatWith
+                            { defaultDecodeSettings | parseNumbers = False }
+                            "1.0"
+                        )
+                        (Err "number parsing is disabled")
+            , test "Do not decode numbers if not parseNumbers" <|
+                \_ ->
+                    Expect.equal
+                        (decodeWith
+                            { defaultDecodeSettings | parseNumbers = False }
+                            "<a>1</a>"
+                        )
+                        (Ok <| Object [ Tag "a" Dict.empty (StrNode "1") ])
             ]
         , describe "Test attributes"
             [ test "Decode tag with single-quoted attribute value" <|

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -333,6 +333,18 @@ all =
                         object [ ( "tagname", Dict.empty, list [] ) ]
                 in
                 Expect.equal (decode "<tagname/>") (Ok val)
+        , describe "Decode test"
+            [ test "decodes emtpy string" <|
+                \_ ->
+                    Expect.equal
+                        (decode "")
+                        (Ok <| Object [])
+            , test "decodes whitespace-only string" <|
+                \_ ->
+                    Expect.equal
+                        (decode "  ")
+                        (Ok <| Object [])
+            ]
         , describe "Test xmlDecoder to convert JSON to XML"
             [ test "decodes string" <|
                 \_ ->

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -325,6 +325,32 @@ all =
                         { defaultEncodeSettings | omitNullTag = False }
                 in
                 Expect.equal (encodeWith setts 0 val) "<tagname></tagname>"
+        , describe "Test decode settings"
+            [ test "Decode bool True" <|
+                \_ ->
+                    Expect.equal
+                        (decodeBool
+                            { defaultDecodeSettings | trueValues = [ "1" ] }
+                            "1"
+                        )
+                        (Ok (bool True))
+            , test "Decode bool False" <|
+                \_ ->
+                    Expect.equal
+                        (decodeBool
+                            { defaultDecodeSettings | falseValues = [ "0", "False" ] }
+                            "False"
+                        )
+                        (Ok (bool False))
+            , test "Decode null" <|
+                \_ ->
+                    Expect.equal
+                        (decodeNull
+                            { defaultDecodeSettings | nullValues = [ "nil", "null" ] }
+                            "nil"
+                        )
+                        (Ok NullNode)
+            ]
         , describe "Test attributes"
             [ test "Decode tag with single-quoted attribute value" <|
                 \_ ->
@@ -358,7 +384,7 @@ all =
                             object [ ( "tagname", Dict.fromList [ ( "attr", NullNode ) ], list [] ) ]
                     in
                     Expect.equal (decode "<tagname attr=\"\" ></tagname>") (Ok val)
-            , test "… therefore, decode attribute value with double-space did not work before I fixed it" <|
+            , test "Decode attribute value with double-space works" <|
                 \_ ->
                     let
                         val =

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -355,11 +355,10 @@ all =
                         (JD.decodeString xmlDecoder """{"a":true}""")
                         (Ok <| Tag "a" Dict.empty (BoolNode True))
             , test "decodes null" <|
-                -- TODO how should it behave?
                 \_ ->
                     Expect.equal
                         (JD.decodeString xmlDecoder """{"a":null}""")
-                        (Ok <| Tag "a" Dict.empty (StrNode ""))
+                        (Ok <| Tag "a" Dict.empty (Object []))
             , test "decodes plain list" <|
                 \_ ->
                     Expect.equal
@@ -374,7 +373,7 @@ all =
                 \_ ->
                     Expect.equal
                         (JD.decodeString xmlDecoder """[null, 1]""")
-                        (Ok <| Object [ StrNode "", IntNode 1 ])
+                        (Ok <| Object [ Object [], IntNode 1 ])
             , test "decode plain object" <|
                 \_ ->
                     Expect.equal
@@ -392,7 +391,7 @@ all =
                         (Ok <|
                             Object
                                 [ Tag "a" Dict.empty (IntNode 1)
-                                , Tag "b" Dict.empty (StrNode "")
+                                , Tag "b" Dict.empty (Object [])
                                 ]
                         )
             ]
@@ -418,16 +417,38 @@ all =
                                 , ( "tag2", Dict.empty, null )
                                 ]
                         )
-            , test "encode object JSON object with one null field" <|
+            , test "encode JSON object with one null field" <|
                 \_ ->
                     Expect.equal
-                        "<tag1></tag1>\n<tag2></tag2>"
+                        "<tag1>x</tag1>\n<tag2></tag2>"
                         (encode 0 <|
                             jsonToXml <|
                                 JE.object
                                     [ ( "tag1", JE.string "x" )
                                     , ( "tag2", JE.null )
                                     ]
+                        )
+            , test "xmlDecoder decodes JSON object with exactly one null field" <|
+                \_ ->
+                    Expect.equal
+                        (Ok <| Tag "tag" Dict.empty (Object []))
+                        (JD.decodeValue xmlDecoder <|
+                            JE.object [ ( "tag", JE.null ) ]
+                        )
+            , test "xmlDecoder decodes JSON object with one null field" <|
+                \_ ->
+                    Expect.equal
+                        (Ok <|
+                            Object
+                                [ Tag "tag1" Dict.empty (StrNode "x")
+                                , Tag "tag2" Dict.empty (Object [])
+                                ]
+                        )
+                        (JD.decodeValue xmlDecoder <|
+                            JE.object
+                                [ ( "tag1", JE.string "x" )
+                                , ( "tag2", JE.null )
+                                ]
                         )
             ]
         , describe "XML character entities &xxx;"

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -364,6 +364,12 @@ all =
                     Expect.equal
                         (JD.decodeString xmlDecoder """["a", 1]""")
                         (Ok <| Object [ StrNode "a", IntNode 1 ])
+            , test "decodes empty list" <|
+                -- same as "null"! not good!
+                \_ ->
+                    Expect.equal
+                        (JD.decodeString xmlDecoder "[]")
+                        (Ok <| Object [])
             , test "decodes list inside a tag" <|
                 \_ ->
                     Expect.equal


### PR DESCRIPTION
I introduced more encode/decode settings and a lot of tests. Also some bug fixes related to attribute/property parsing.

Specifically, I needed the feature that JSON `null` is not encoded as XML tag but is simply omitted.

- fix parsing of attribute values
  - empty values are allowed
  - consecutive spaces are allowed
  - both single quote and double quotes are allowed
- new Value type constructor NullNode to allow a representation of null
- encode settings
  - option to omit null tags (only if no attributes are present)
  - custom string value for NullNode (e.g. null, NA, nil)
  - custom string value for true/false (e.g. 0/1, T/F)
  - single or double quoting for attribute values
- decode settings
  - selection of strings that are parsed as NullNode
  - selection of strings that are parsed as True/False
- JSON/XML conversion: add null support
